### PR TITLE
Feature: Worm fishing lava ESP

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
     idea
 }
 
-version = "0.1.3-pre1"
+version = "0.1.3-pre2"
 group = "skyblockclient"
 
 minecraft {

--- a/src/main/kotlin/skyblockclient/SkyblockClient.kt
+++ b/src/main/kotlin/skyblockclient/SkyblockClient.kt
@@ -66,6 +66,7 @@ class SkyblockClient {
             F7P3Ghost(),
             FastLeap(),
             GemstoneESP(),
+            WormFishingLavaESP(),
             GhostBlock(),
             HiddenMobs(),
             ImpactParticles(),
@@ -146,7 +147,7 @@ class SkyblockClient {
     companion object {
         const val MOD_ID = "sbclient"
         const val MOD_NAME = "Skyblock Client"
-        const val MOD_VERSION = "0.1.3-pre1"
+        const val MOD_VERSION = "0.1.3-pre2"
         const val CHAT_PREFIX = "§b§l<§fSkyblockClient§b§l>§r"
         val mc: Minecraft = Minecraft.getMinecraft()
         var config = Config

--- a/src/main/kotlin/skyblockclient/config/Config.kt
+++ b/src/main/kotlin/skyblockclient/config/Config.kt
@@ -5,6 +5,7 @@ import gg.essential.vigilance.data.Category
 import gg.essential.vigilance.data.Property
 import gg.essential.vigilance.data.PropertyType
 import gg.essential.vigilance.data.SortingBehavior
+import net.minecraft.util.EnumChatFormatting
 import skyblockclient.SkyblockClient.Companion.display
 import skyblockclient.guis.BlockAnimationBlacklist
 import skyblockclient.guis.HideModID
@@ -780,6 +781,53 @@ object Config : Vigilant(File("./config/sbclient/config.toml"), "SkyblockClient"
 
     @Property(
         type = PropertyType.SWITCH,
+        name = "Worm fishing esp",
+        description = "Detects lava in precursor remnants above Y=64.\n\nMade by TheStachelfisch",
+        category = "Misc",
+        subcategory = "Mining"
+    )
+    var wormFishingLavaESP = false
+
+    @Property(
+        type = PropertyType.NUMBER,
+        name = "Worm fishing ESP Radius",
+        category = "Misc",
+        subcategory = "Mining",
+        max = 150
+    )
+    var wormFishingLavaESPRadius = 50
+
+    @Property(
+        type = PropertyType.NUMBER,
+        name = "Worm fishing ESP Time",
+        description = "Time in ms between scan cycles.",
+        category = "Misc",
+        subcategory = "Mining",
+        increment = 10,
+        max = 5000
+    )
+    var wormFishingLavaESPTime = 750
+
+    @Property(
+        type = PropertyType.CHECKBOX,
+        name = "Hide ESP near lava",
+        description = "Hide ESP when near lava.",
+        category = "Misc",
+        subcategory = "Mining",
+    )
+    var wormFishingLavaHideNear = true
+
+    @Property(
+        type = PropertyType.CHECKBOX,
+        name = "Turn off ESP after fishing up worm.",
+        description = "Only turns it off for current session.",
+        category = "Misc",
+        subcategory = "Mining",
+    )
+    var wormFishingHideFished = true
+
+    @Property(
+        type = PropertyType.SWITCH,
         name = "Right Click Ghost Block",
         description = "Right click with a Stonk to create ghost block.",
         category = "Misc",
@@ -879,6 +927,14 @@ object Config : Vigilant(File("./config/sbclient/config.toml"), "SkyblockClient"
             "gemstoneTopaz"
         ).forEach(Consumer { s: String ->
             addDependency(s, "gemstoneESP")
+        })
+        listOf(
+            "wormFishingLavaESPRadius",
+            "wormFishingLavaESPTime",
+            "wormFishingLavaHideNear",
+            "wormFishingHideFished"
+        ).forEach(Consumer { s: String ->
+            addDependency(s, "wormFishingLavaESP")
         })
     }
 

--- a/src/main/kotlin/skyblockclient/config/Config.kt
+++ b/src/main/kotlin/skyblockclient/config/Config.kt
@@ -818,7 +818,7 @@ object Config : Vigilant(File("./config/sbclient/config.toml"), "SkyblockClient"
 
     @Property(
         type = PropertyType.CHECKBOX,
-        name = "Turn off ESP after fishing up worm.",
+        name = "Turn off ESP after fishing up worm",
         description = "Only turns it off for current session.",
         category = "Misc",
         subcategory = "Mining",

--- a/src/main/kotlin/skyblockclient/config/Config.kt
+++ b/src/main/kotlin/skyblockclient/config/Config.kt
@@ -5,7 +5,6 @@ import gg.essential.vigilance.data.Category
 import gg.essential.vigilance.data.Property
 import gg.essential.vigilance.data.PropertyType
 import gg.essential.vigilance.data.SortingBehavior
-import net.minecraft.util.EnumChatFormatting
 import skyblockclient.SkyblockClient.Companion.display
 import skyblockclient.guis.BlockAnimationBlacklist
 import skyblockclient.guis.HideModID

--- a/src/main/kotlin/skyblockclient/features/WormFishingLavaESP.kt
+++ b/src/main/kotlin/skyblockclient/features/WormFishingLavaESP.kt
@@ -1,0 +1,89 @@
+package skyblockclient.features
+
+import net.minecraft.init.Blocks
+import net.minecraft.util.BlockPos
+import net.minecraft.util.Vec3i
+import net.minecraftforge.client.event.ClientChatReceivedEvent
+import net.minecraftforge.client.event.RenderWorldLastEvent
+import net.minecraftforge.event.world.WorldEvent
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import net.minecraftforge.fml.common.gameevent.TickEvent
+import skyblockclient.SkyblockClient
+import skyblockclient.utils.RenderUtils
+import skyblockclient.utils.ScoreboardUtils
+import java.awt.Color
+
+class WormFishingLavaESP {
+    private val lavaBlocksList: MutableList<BlockPos> = mutableListOf()
+    private var lastUpdate: Long = 0
+    private val locations = listOf(
+        "Precursor Remnants",
+        "Lost Precursor City",
+        "Magma Fields",
+        "Khazad-dûm",
+    )
+    private var thread: Thread? = null
+    private var disabledInSession: Boolean = false
+
+    //#region ESP
+    @SubscribeEvent
+    fun onTick(event: TickEvent.ClientTickEvent) {
+        if (event.phase != TickEvent.Phase.START || !SkyblockClient.config.wormFishingLavaESP || !isCrystalHollow()) return
+        if (thread?.isAlive == true || lastUpdate + SkyblockClient.config.wormFishingLavaESPTime > System.currentTimeMillis()) return
+        thread = Thread({
+            val blockList: MutableList<BlockPos> = mutableListOf()
+            val player = SkyblockClient.mc.thePlayer.position
+            val radius = SkyblockClient.config.wormFishingLavaESPRadius
+            val vec3i = Vec3i(radius, radius, radius)
+
+            BlockPos.getAllInBox(player.add(vec3i), player.subtract(vec3i)).forEach {
+                val blockState = SkyblockClient.mc.theWorld.getBlockState(it)
+
+                if ((blockState.block == Blocks.lava || blockState.block == Blocks.flowing_lava) && it.y > 64)
+                    blockList.add(it)
+            }
+            synchronized(lavaBlocksList) {
+                lavaBlocksList.clear()
+                lavaBlocksList.addAll(blockList)
+            }
+            lastUpdate = System.currentTimeMillis()
+        }, "Worm fishing ESP")
+        thread!!.start()
+    }
+
+    @SubscribeEvent
+    fun onRenderWorld(event: RenderWorldLastEvent) {
+        if (!SkyblockClient.config.wormFishingLavaESP || !isCrystalHollow()) return
+
+        val player = SkyblockClient.mc.thePlayer.position
+        synchronized(lavaBlocksList) {
+            lavaBlocksList.forEach { blockPos ->
+                if (!disabledInSession)
+                    if (player.distanceSq(blockPos) > 40 && SkyblockClient.config.wormFishingLavaHideNear)
+                        RenderUtils.drawBlockBox(blockPos, Color.ORANGE, outline = true, fill = true, event.partialTicks)
+                    else if (!SkyblockClient.config.wormFishingLavaHideNear)
+                        RenderUtils.drawBlockBox(blockPos, Color.ORANGE, outline = true, fill = true, event.partialTicks)
+            }
+        }
+    }
+
+    @SubscribeEvent
+    fun onChatMessage(event: ClientChatReceivedEvent) {
+        if (!SkyblockClient.config.wormFishingHideFished) return
+
+        if (event.message.unformattedText == "A flaming worm surfaces from the depths!")
+            disabledInSession = true
+    }
+
+    @SubscribeEvent
+    fun onChangeWorld(event: WorldEvent.Load) {
+        if (!SkyblockClient.config.wormFishingHideFished || !disabledInSession) return
+
+        disabledInSession = false
+    }
+    //#endregion
+
+    private fun isCrystalHollow(): Boolean {
+        return SkyblockClient.inSkyblock && ScoreboardUtils.sidebarLines.any { s -> locations.any { ScoreboardUtils.cleanSB(s).contains(it) } } || SkyblockClient.config.forceSkyblock
+    }
+}

--- a/src/main/kotlin/skyblockclient/features/WormFishingLavaESP.kt
+++ b/src/main/kotlin/skyblockclient/features/WormFishingLavaESP.kt
@@ -9,6 +9,9 @@ import net.minecraftforge.event.world.WorldEvent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import net.minecraftforge.fml.common.gameevent.TickEvent
 import skyblockclient.SkyblockClient
+import skyblockclient.SkyblockClient.Companion.config
+import skyblockclient.SkyblockClient.Companion.inSkyblock
+import skyblockclient.SkyblockClient.Companion.mc
 import skyblockclient.utils.RenderUtils
 import skyblockclient.utils.ScoreboardUtils
 import java.awt.Color
@@ -28,16 +31,16 @@ class WormFishingLavaESP {
     //#region ESP
     @SubscribeEvent
     fun onTick(event: TickEvent.ClientTickEvent) {
-        if (event.phase != TickEvent.Phase.START || !SkyblockClient.config.wormFishingLavaESP || !isCrystalHollow()) return
-        if (thread?.isAlive == true || lastUpdate + SkyblockClient.config.wormFishingLavaESPTime > System.currentTimeMillis()) return
+        if (event.phase != TickEvent.Phase.START || !config.wormFishingLavaESP || !isCrystalHollow()) return
+        if (thread?.isAlive == true || lastUpdate + config.wormFishingLavaESPTime > System.currentTimeMillis()) return
         thread = Thread({
             val blockList: MutableList<BlockPos> = mutableListOf()
-            val player = SkyblockClient.mc.thePlayer.position
-            val radius = SkyblockClient.config.wormFishingLavaESPRadius
+            val player = mc.thePlayer.position
+            val radius = config.wormFishingLavaESPRadius
             val vec3i = Vec3i(radius, radius, radius)
 
             BlockPos.getAllInBox(player.add(vec3i), player.subtract(vec3i)).forEach {
-                val blockState = SkyblockClient.mc.theWorld.getBlockState(it)
+                val blockState = mc.theWorld.getBlockState(it)
 
                 if ((blockState.block == Blocks.lava || blockState.block == Blocks.flowing_lava) && it.y > 64)
                     blockList.add(it)
@@ -53,15 +56,15 @@ class WormFishingLavaESP {
 
     @SubscribeEvent
     fun onRenderWorld(event: RenderWorldLastEvent) {
-        if (!SkyblockClient.config.wormFishingLavaESP || !isCrystalHollow()) return
+        if (!config.wormFishingLavaESP || !isCrystalHollow()) return
 
-        val player = SkyblockClient.mc.thePlayer.position
+        val player = mc.thePlayer.position
         synchronized(lavaBlocksList) {
             lavaBlocksList.forEach { blockPos ->
                 if (!disabledInSession)
-                    if (player.distanceSq(blockPos) > 40 && SkyblockClient.config.wormFishingLavaHideNear)
+                    if (player.distanceSq(blockPos) > 40 && config.wormFishingLavaHideNear)
                         RenderUtils.drawBlockBox(blockPos, Color.ORANGE, outline = true, fill = true, event.partialTicks)
-                    else if (!SkyblockClient.config.wormFishingLavaHideNear)
+                    else if (!config.wormFishingLavaHideNear)
                         RenderUtils.drawBlockBox(blockPos, Color.ORANGE, outline = true, fill = true, event.partialTicks)
             }
         }
@@ -69,7 +72,7 @@ class WormFishingLavaESP {
 
     @SubscribeEvent
     fun onChatMessage(event: ClientChatReceivedEvent) {
-        if (!SkyblockClient.config.wormFishingHideFished) return
+        if (!config.wormFishingHideFished) return
 
         if (event.message.unformattedText == "A flaming worm surfaces from the depths!")
             disabledInSession = true
@@ -77,13 +80,13 @@ class WormFishingLavaESP {
 
     @SubscribeEvent
     fun onChangeWorld(event: WorldEvent.Load) {
-        if (!SkyblockClient.config.wormFishingHideFished || !disabledInSession) return
+        if (!config.wormFishingHideFished || !disabledInSession) return
 
         disabledInSession = false
     }
     //#endregion
 
     private fun isCrystalHollow(): Boolean {
-        return SkyblockClient.inSkyblock && ScoreboardUtils.sidebarLines.any { s -> locations.any { ScoreboardUtils.cleanSB(s).contains(it) } } || SkyblockClient.config.forceSkyblock
+        return inSkyblock && ScoreboardUtils.sidebarLines.any { s -> locations.any { ScoreboardUtils.cleanSB(s).contains(it) } } || config.forceSkyblock
     }
 }


### PR DESCRIPTION
## Description
This is a simple feature that adds ESP to finding "flaming worm fishable" lava in the precursor remnants. It detects every lava source above Y=64 and marks it with a filled box.

After doing tests I found that I can find at least one fishable spot in every lobby. Takes less than 20 seconds instead of switching lobbies and running around aimlessly each time.

It automatically disables for the current session after a worm was fished up.

## Features
- Non-complicated code. Similar to Gemstone ESP
- Thread based
- Config options to configure it
- Hides ESP while near lava blocks
- Automatically disables ESP after fishing up a worm for the current session. 
- Thoroughly tested

## Checks

- [X] Added config options
- [X] Tested the feature
- [X] Bumped Version number
- [X] Formatted code